### PR TITLE
Fix import paths after moving pages to app

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -1,6 +1,6 @@
 import './App.css'
-import Pages from "@/pages/index.jsx"
-import { Toaster } from "@/components/ui/toaster"
+import Pages from "./app/index.jsx"
+import { Toaster } from "./components/ui/toaster"
 
 function App() {
   return (

--- a/app/Consent.jsx
+++ b/app/Consent.jsx
@@ -1,15 +1,15 @@
 
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { createPageUrl } from "@/utils";
-import { User } from "@/api/entities";
-import { EventProfile } from "@/api/entities";
-import { Event } from "@/api/entities";
-import { UploadFile } from "@/api/integrations";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { createPageUrl } from "../utils";
+import { User } from "../api/entities";
+import { EventProfile } from "../api/entities";
+import { Event } from "../api/entities";
+import { UploadFile } from "../api/integrations";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
 import { Check, Shield, User as UserIcon, LogIn, Heart, Camera, Upload, Facebook, Instagram } from "lucide-react";
 import { toast } from 'sonner';
 import { motion, AnimatePresence } from "framer-motion";

--- a/app/Discovery.jsx
+++ b/app/Discovery.jsx
@@ -1,12 +1,12 @@
 
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { createPageUrl } from "@/utils";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { createPageUrl } from "../utils";
+import { Card, CardContent } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
 import { Heart, Filter, Users, Sparkles, Image as ImageIcon } from "lucide-react";
-import { EventProfile, Like, Event } from "@/api/entities";
+import { EventProfile, Like, Event } from "../api/entities";
 import ProfileFilters from "../components/ProfileFilters";
 import ProfileDetailModal from "../components/ProfileDetailModal";
 import FirstTimeGuideModal from "../components/FirstTimeGuideModal";

--- a/app/Home.jsx
+++ b/app/Home.jsx
@@ -1,11 +1,11 @@
 
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { createPageUrl } from "@/utils";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { createPageUrl } from "../utils";
+import { Button } from "../components/ui/button";
+import { Card, CardContent, CardHeader } from "../components/ui/card";
 import { QrCode, Hash, Heart, Shield, Clock, Users } from "lucide-react";
-import { Event } from "@/api/entities";
+import { Event } from "../api/entities";
 import QRScanner from "../components/QRScanner";
 import EventCodeEntry from "../components/EventCodeEntry";
 

--- a/app/Layout.jsx
+++ b/app/Layout.jsx
@@ -2,14 +2,14 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { createPageUrl } from "@/utils";
+import { createPageUrl } from "../utils";
 import { Heart, User, Users, Home, MessageCircle } from "lucide-react";
-import { Like, EventProfile, Event, Message } from "@/api/entities"; // Import Message entity
+import { Like, EventProfile, Event, Message } from "../api/entities"; // Import Message entity
 import MatchNotificationToast from "../components/MatchNotificationToast";
 import MessageNotificationToast from "../components/MessageNotificationToast"; // Import MessageNotificationToast
 import FeedbackSurveyModal from "../components/FeedbackSurveyModal"; // Import FeedbackSurveyModal
 import { AnimatePresence } from "framer-motion";
-import { Toaster } from "@/components/ui/sonner";
+import { Toaster } from "../components/ui/sonner";
 
 export default function Layout({ children, currentPageName }) {
   const location = useLocation();

--- a/app/Matches.jsx
+++ b/app/Matches.jsx
@@ -1,12 +1,12 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { createPageUrl } from "@/utils";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { createPageUrl } from "../utils";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Button } from "../components/ui/button";
+import { Badge } from "../components/ui/badge";
 import { Heart, MessageCircle, Users, Sparkles } from "lucide-react";
-import { EventProfile, Like, Message } from "@/api/entities";
+import { EventProfile, Like, Message } from "../api/entities";
 import ChatModal from "../components/ChatModal";
 import ProfileDetailModal from "../components/ProfileDetailModal"; // Added import
 

--- a/app/Profile.jsx
+++ b/app/Profile.jsx
@@ -1,16 +1,16 @@
 
 import React, { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { createPageUrl } from "@/utils";
-import { User } from "@/api/entities";
-import { EventProfile } from "@/api/entities";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Switch } from "@/components/ui/switch";
-import { Badge } from "@/components/ui/badge";
-import { UploadFile } from "@/api/integrations";
+import { createPageUrl } from "../utils";
+import { User } from "../api/entities";
+import { EventProfile } from "../api/entities";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Textarea } from "../components/ui/textarea";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Switch } from "../components/ui/switch";
+import { Badge } from "../components/ui/badge";
+import { UploadFile } from "../api/integrations";
 import { User as UserIcon, Edit, Save, Trash2, Eye, EyeOff, X, Camera, Sparkles, LogOut, AlertCircle, Clock, Mail, CheckCircle2 } from "lucide-react";
 import { toast } from "sonner";
 

--- a/app/admin.jsx
+++ b/app/admin.jsx
@@ -1,12 +1,12 @@
 
 import React, { useState, useEffect } from 'react';
-import { Event, EventProfile, Like, Message, EventFeedback } from '@/api/entities';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge'; // Added Badge import
+import { Event, EventProfile, Like, Message, EventFeedback } from '../api/entities';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '../components/ui/card';
+import { Badge } from '../components/ui/badge'; // Added Badge import
 import { Copy, Download, Loader2, PlusCircle, BarChart2, Edit, Trash2, FileImage, MessageSquare, Hash, MapPin } from 'lucide-react'; // Added Hash, MapPin imports
-import { toast, Toaster } from "@/components/ui/sonner";
+import { toast, Toaster } from "../components/ui/sonner";
 import QRCodeGenerator from '../components/QRCodeGenerator';
 import EventFormModal from '../components/admin/EventFormModal';
 import EventAnalyticsModal from '../components/admin/EventAnalyticsModal';

--- a/app/join.jsx
+++ b/app/join.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { createPageUrl } from "@/utils";
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
+import { createPageUrl } from "../utils";
+import { Card, CardContent } from "../components/ui/card";
+import { Button } from "../components/ui/button";
 import { AlertCircle, Calendar, MapPin, Clock } from "lucide-react";
-import { Event } from "@/api/entities";
+import { Event } from "../api/entities";
 
 export default function JoinPage() {
   const navigate = useNavigate();
@@ -70,7 +70,7 @@ export default function JoinPage() {
       if (existingSessionId) {
         // User might be returning - verify their profile still exists
         try {
-          const { EventProfile } = await import('@/api/entities');
+          const { EventProfile } = await import('../api/entities');
           const existingProfiles = await EventProfile.filter({
             session_id: existingSessionId,
             event_id: foundEvent.id

--- a/components.json
+++ b/components.json
@@ -10,12 +10,6 @@
     "cssVariables": true,
     "prefix": ""
   },
-  "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib",
-    "hooks": "@/hooks"
-  },
+  "aliases": {},
   "iconLibrary": "lucide"
 }

--- a/components/ChatModal.jsx
+++ b/components/ChatModal.jsx
@@ -5,12 +5,12 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
+} from "./ui/dialog";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Badge } from "./ui/badge";
 import { Send, X, Clock, Share, Phone, User } from "lucide-react";
-import { Message, ContactShare } from "@/api/entities";
+import { Message, ContactShare } from "../api/entities";
 import { format } from "date-fns";
 import ContactShareModal from "./ContactShareModal";
 

--- a/components/ContactShareModal.jsx
+++ b/components/ContactShareModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
 import { X, Phone, User, CheckCircle } from 'lucide-react';
 import { motion } from 'framer-motion';
 

--- a/components/EventCodeEntry.jsx
+++ b/components/EventCodeEntry.jsx
@@ -5,9 +5,9 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+} from "./ui/dialog";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
 import { Hash, ArrowRight, X } from "lucide-react";
 
 export default function EventCodeEntry({ onSubmit, onClose }) {

--- a/components/FeedbackSurveyModal.jsx
+++ b/components/FeedbackSurveyModal.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Textarea } from './ui/textarea';
+import { Label } from './ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { X, Heart, Star } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { EventFeedback } from '@/api/entities';
+import { EventFeedback } from '../api/entities';
 import { toast } from 'sonner';
 
 export default function FeedbackSurveyModal({ event, sessionId, onClose }) {

--- a/components/MatchNotificationToast.jsx
+++ b/components/MatchNotificationToast.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createPageUrl } from '@/utils';
-import { Button } from '@/components/ui/button';
+import { createPageUrl } from '../utils';
+import { Button } from './ui/button';
 import { X, PartyPopper, ArrowRight } from 'lucide-react';
 import { motion } from 'framer-motion';
 

--- a/components/MessageNotificationToast.jsx
+++ b/components/MessageNotificationToast.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { createPageUrl } from '@/utils';
-import { Button } from '@/components/ui/button';
+import { createPageUrl } from '../utils';
+import { Button } from './ui/button';
 import { X, MessageCircle, ArrowRight } from 'lucide-react';
 import { motion } from 'framer-motion';
 

--- a/components/ProfileDetailModal.jsx
+++ b/components/ProfileDetailModal.jsx
@@ -2,8 +2,8 @@
 import React, { useEffect } from 'react';
 import { X, Heart, Calendar, Ruler, User } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
 
 export default function ProfileDetailModal({ profile, onClose, onLike, isLiked }) {
   useEffect(() => {

--- a/components/ProfileFilters.jsx
+++ b/components/ProfileFilters.jsx
@@ -4,11 +4,11 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import { Badge } from "@/components/ui/badge";
-import { Slider } from "@/components/ui/slider";
+} from "./ui/dialog";
+import { Button } from "./ui/button";
+import { Label } from "./ui/label";
+import { Badge } from "./ui/badge";
+import { Slider } from "./ui/slider";
 import { Filter, X, ChevronDown, ChevronUp } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 

--- a/components/QRCodeGenerator.jsx
+++ b/components/QRCodeGenerator.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button } from '@/components/ui/button';
+import { Button } from './ui/button';
 import { Download, AlertCircle } from 'lucide-react';
-import { toast } from "@/components/ui/sonner";
+import { toast } from "./ui/sonner";
 
 const QR_API_BASE = 'https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=';
 

--- a/components/QRScanner.jsx
+++ b/components/QRScanner.jsx
@@ -1,9 +1,9 @@
 
 import React, { useRef, useEffect, useState, useCallback } from "react";
-import { Dialog } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
+import { Dialog } from "./ui/dialog";
+import { Button } from "./ui/button";
 import { Camera, X } from "lucide-react";
-import { toast } from "@/components/ui/sonner";
+import { toast } from "./ui/sonner";
 
 export default function QRScanner({ onScan, onClose, onSwitchToManual }) {
   const videoRef = useRef(null);

--- a/components/admin/DeleteConfirmationDialog.jsx
+++ b/components/admin/DeleteConfirmationDialog.jsx
@@ -8,8 +8,8 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import { Button } from '@/components/ui/button';
+} from '../ui/alert-dialog';
+import { Button } from '../ui/button';
 
 export default function DeleteConfirmationDialog({ isOpen, onClose, onConfirm, eventName }) {
   return (

--- a/components/admin/EventAnalyticsModal.jsx
+++ b/components/admin/EventAnalyticsModal.jsx
@@ -4,10 +4,10 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { EventProfile, Like, Message } from '@/api/entities';
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { EventProfile, Like, Message } from '../../api/entities';
 import { X, Users, Heart, MessageCircle, Calendar } from 'lucide-react';
 import { format } from 'date-fns';
 

--- a/components/admin/EventFormModal.jsx
+++ b/components/admin/EventFormModal.jsx
@@ -5,14 +5,14 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { Label } from '@/components/ui/label';
-import { Event } from '@/api/entities';
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Textarea } from '../ui/textarea';
+import { Label } from '../ui/label';
+import { Event } from '../../api/entities';
 import { X, Save, Loader2 } from 'lucide-react';
-import { toast } from "@/components/ui/sonner";
+import { toast } from "../ui/sonner";
 import { format } from 'date-fns';
 
 export default function EventFormModal({ event, isOpen, onClose, onSuccess }) {

--- a/components/admin/FeedbackInsightsModal.jsx
+++ b/components/admin/FeedbackInsightsModal.jsx
@@ -4,12 +4,12 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { EventFeedback } from '@/api/entities';
+} from '../ui/dialog';
+import { Button } from '../ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Badge } from '../ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
+import { EventFeedback } from '../../api/entities';
 import { X, MessageSquare, Star, Users, CheckCircle, XCircle } from 'lucide-react';
 
 export default function FeedbackInsightsModal({ event, isOpen, onClose }) {

--- a/components/ui/alert-dialog.jsx
+++ b/components/ui/alert-dialog.jsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "../../lib/utils"
+import { buttonVariants } from "./button"
 
 const AlertDialog = AlertDialogPrimitive.Root
 

--- a/components/ui/alert.jsx
+++ b/components/ui/alert.jsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",

--- a/components/ui/badge.jsx
+++ b/components/ui/badge.jsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/components/ui/button.jsx
+++ b/components/ui/button.jsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",

--- a/components/ui/calendar.jsx
+++ b/components/ui/calendar.jsx
@@ -2,8 +2,8 @@ import * as React from "react"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "../../lib/utils"
+import { buttonVariants } from "./button"
 
 function Calendar({
   className,

--- a/components/ui/card.jsx
+++ b/components/ui/card.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Card = React.forwardRef(({ className, ...props }, ref) => (
   <div

--- a/components/ui/carousel.jsx
+++ b/components/ui/carousel.jsx
@@ -2,8 +2,8 @@ import * as React from "react"
 import useEmblaCarousel from "embla-carousel-react";
 import { ArrowLeft, ArrowRight } from "lucide-react"
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from "../../lib/utils"
+import { Button } from "./button"
 
 const CarouselContext = React.createContext(null)
 

--- a/components/ui/chart.jsx
+++ b/components/ui/chart.jsx
@@ -2,7 +2,7 @@
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = {

--- a/components/ui/checkbox.jsx
+++ b/components/ui/checkbox.jsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { Check } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Checkbox = React.forwardRef(({ className, ...props }, ref) => (
   <CheckboxPrimitive.Root

--- a/components/ui/command.jsx
+++ b/components/ui/command.jsx
@@ -2,8 +2,8 @@ import * as React from "react"
 import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
-import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { cn } from "../../lib/utils"
+import { Dialog, DialogContent } from "./dialog"
 
 const Command = React.forwardRef(({ className, ...props }, ref) => (
   <CommandPrimitive

--- a/components/ui/dialog.jsx
+++ b/components/ui/dialog.jsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Dialog = DialogPrimitive.Root
 

--- a/components/ui/drawer.jsx
+++ b/components/ui/drawer.jsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Drawer = ({
   shouldScaleBackground = true,

--- a/components/ui/input-otp.jsx
+++ b/components/ui/input-otp.jsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
 import { Minus } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const InputOTP = React.forwardRef(({ className, containerClassName, ...props }, ref) => (
   <OTPInput

--- a/components/ui/input.jsx
+++ b/components/ui/input.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Input = React.forwardRef(({ className, type, ...props }, ref) => {
   return (

--- a/components/ui/label.jsx
+++ b/components/ui/label.jsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"

--- a/components/ui/pagination.jsx
+++ b/components/ui/pagination.jsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button";
+import { cn } from "../../lib/utils"
+import { buttonVariants } from "./button";
 
 const Pagination = ({
   className,

--- a/components/ui/progress.jsx
+++ b/components/ui/progress.jsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Progress = React.forwardRef(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root

--- a/components/ui/radio-group.jsx
+++ b/components/ui/radio-group.jsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { Circle } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const RadioGroup = React.forwardRef(({ className, ...props }, ref) => {
   return (<RadioGroupPrimitive.Root className={cn("grid gap-2", className)} {...props} ref={ref} />);

--- a/components/ui/resizable.jsx
+++ b/components/ui/resizable.jsx
@@ -3,7 +3,7 @@
 import { GripVertical } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const ResizablePanelGroup = ({
   className,

--- a/components/ui/select.jsx
+++ b/components/ui/select.jsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Select = SelectPrimitive.Root
 

--- a/components/ui/skeleton.jsx
+++ b/components/ui/skeleton.jsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 function Skeleton({
   className,

--- a/components/ui/switch.jsx
+++ b/components/ui/switch.jsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SwitchPrimitives from "@radix-ui/react-switch"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Switch = React.forwardRef(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root

--- a/components/ui/table.jsx
+++ b/components/ui/table.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Table = React.forwardRef(({ className, ...props }, ref) => (
   <div className="relative w-full overflow-auto">

--- a/components/ui/textarea.jsx
+++ b/components/ui/textarea.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Textarea = React.forwardRef(({ className, ...props }, ref) => {
   return (

--- a/components/ui/toast.jsx
+++ b/components/ui/toast.jsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { cva } from "class-variance-authority";
 import { X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 
 const ToastProvider = React.forwardRef(({ ...props }, ref) => (
   <div

--- a/components/ui/toaster.jsx
+++ b/components/ui/toaster.jsx
@@ -1,4 +1,4 @@
-import { useToast } from "@/components/ui/use-toast";
+import { useToast } from "./use-toast";
 import {
   Toast,
   ToastClose,
@@ -6,7 +6,7 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "@/components/ui/toast";
+} from "./toast";
 
 export function Toaster() {
   const { toasts } = useToast();

--- a/components/ui/tooltip.jsx
+++ b/components/ui/tooltip.jsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,10 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
+    "paths": {},
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*.js", "src/**/*.jsx"]
-} 
+  "include": ["app/**/*.js", "app/**/*.jsx", "components/**/*.jsx", "api/**/*.js", "lib/**/*.js", "utils/**/*.ts"]
+}

--- a/main.jsx
+++ b/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from '@/App.jsx'
-import '@/index.css'
+import App from './App.jsx'
+import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
     <App />


### PR DESCRIPTION
## Summary
- update all imports to use relative paths
- stop using old `pages` alias
- trim unused alias configuration in `components.json` and `jsconfig.json`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686a2912f1c083288c99550778ed2a22