### PR TITLE
Add local profile prefilling

### DIFF
--- a/lib/localProfile.ts
+++ b/lib/localProfile.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Profile } from './firebase/firestore';
+
+export interface LocalProfile extends Profile {
+  profile_photo_url?: string;
+}
+
+const LOCAL_PROFILE_KEY = 'localProfile';
+
+function isLocalProfile(data: unknown): data is LocalProfile {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const p = data as Record<string, unknown>;
+  if (typeof p.fullName !== 'string') {
+    return false;
+  }
+  if (p.phoneNumber !== undefined && typeof p.phoneNumber !== 'string') {
+    return false;
+  }
+  if (p.age !== undefined && typeof p.age !== 'number') {
+    return false;
+  }
+  if (p.gender !== undefined && typeof p.gender !== 'string') {
+    return false;
+  }
+  if (p.instagram !== undefined && typeof p.instagram !== 'string') {
+    return false;
+  }
+  if (p.interests !== undefined && !Array.isArray(p.interests)) {
+    return false;
+  }
+  if (p.profile_photo_url !== undefined && typeof p.profile_photo_url !== 'string') {
+    return false;
+  }
+  return true;
+}
+
+export async function saveLocalProfile(profile: LocalProfile): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LOCAL_PROFILE_KEY, JSON.stringify(profile));
+  } catch (error) {
+    console.error('Error saving local profile:', error);
+  }
+}
+
+export async function getLocalProfile(): Promise<LocalProfile | null> {
+  try {
+    const json = await AsyncStorage.getItem(LOCAL_PROFILE_KEY);
+    if (!json) return null;
+    const data = JSON.parse(json);
+    if (isLocalProfile(data)) {
+      return data;
+    }
+    return null;
+  } catch (error) {
+    console.error('Error retrieving local profile:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- store saved profile info locally
- prefill consent form using saved profile data

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686a84fca6ac832897d62a6c8da7b2ff